### PR TITLE
java docker image update

### DIFF
--- a/comment-service/Dockerfile
+++ b/comment-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre
+FROM openjdk:8-jdk-alpine
 MAINTAINER Cassio Mazzochi Molin <cassio@cassiomolin.com>
 
 VOLUME /tmp

--- a/post-service/Dockerfile
+++ b/post-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre
+FROM openjdk:8-jdk-alpine
 MAINTAINER Cassio Mazzochi Molin <cassio@cassiomolin.com>
 
 VOLUME /tmp


### PR DESCRIPTION
As I saw that there is no specific java-9, 10 ,11 features, we can use jdk-8-alphine for lighter image.